### PR TITLE
Use the absolute binary path to pip and app

### DIFF
--- a/base.docker
+++ b/base.docker
@@ -12,4 +12,4 @@ RUN apt-get install -qyy \
     python-virtualenv pypy libffi6 openssl
 
 RUN virtualenv -p /usr/bin/pypy /appenv
-RUN . /appenv/bin/activate; pip install pip==6.0.8
+RUN /appenv/bin/pip install pip==6.0.8

--- a/build.docker
+++ b/build.docker
@@ -1,8 +1,7 @@
 FROM deployme-base
 
 RUN apt-get install -qy libffi-dev libssl-dev pypy-dev
-RUN . /appenv/bin/activate; \
-    pip install wheel
+RUN /appenv/bin/pip install wheel
 
 ENV WHEELHOUSE=/wheelhouse
 ENV PIP_WHEEL_DIR=/wheelhouse
@@ -11,6 +10,5 @@ ENV PIP_FIND_LINKS=/wheelhouse
 VOLUME /wheelhouse
 VOLUME /application
 
-ENTRYPOINT . /appenv/bin/activate; \
-           cd /application; \
-           pip wheel .
+ENTRYPOINT cd /application; \
+           /appenv/bin/pip wheel .

--- a/run.docker
+++ b/run.docker
@@ -1,10 +1,8 @@
 FROM deployme-base
 
 ADD wheelhouse /wheelhouse
-RUN . /appenv/bin/activate; \
-    pip install --no-index -f wheelhouse DeployMe
+RUN /appenv/bin/pip install --no-index -f wheelhouse DeployMe
 
 EXPOSE 8081
 
-ENTRYPOINT . /appenv/bin/activate; \
-           run-the-app
+ENTRYPOINT /appenv/bin/run-the-app


### PR DESCRIPTION
Instead of activating the virtualenv and then use the binary name to do install package, we can use directly the absolute binary path to do the same thing in one command line.
