### PR TITLE
make sure that the wheel version is in sync with pip 

### DIFF
--- a/build.docker
+++ b/build.docker
@@ -2,7 +2,7 @@ FROM deployme-base
 
 RUN apt-get install -qy libffi-dev libssl-dev pypy-dev
 RUN . /appenv/bin/activate; \
-    pip install wheel
+    pip install wheel==0.26.0
 
 ENV WHEELHOUSE=/wheelhouse
 ENV PIP_WHEEL_DIR=/wheelhouse


### PR DESCRIPTION
as of right now, the build breaks, so far from what I can tell the newest wheel does not work well with any version of pip. see [here](https://bitbucket.org/pypa/wheel/issues/159/cant-install-wheels-with-the-pip-version)
